### PR TITLE
use port 6443

### DIFF
--- a/cert-manager-webhook-ibmcis.yaml
+++ b/cert-manager-webhook-ibmcis.yaml
@@ -153,7 +153,7 @@ spec:
   type: ClusterIP
   ports:
     - port: 443
-      targetPort: https
+      targetPort: 6443
       protocol: TCP
       name: https
   selector:
@@ -191,6 +191,7 @@ spec:
           args:
             - --tls-cert-file=/tls/tls.crt
             - --tls-private-key-file=/tls/tls.key
+            - --secure-port=6443
           env:
             - name: GROUP_NAME
               value: "acme.borup.work"
@@ -201,7 +202,7 @@ spec:
                   key: api-token
           ports:
             - name: https
-              containerPort: 443
+              containerPort: 6443
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/deploy/cert-manager-webhook-ibmcis/templates/deployment.yaml
+++ b/deploy/cert-manager-webhook-ibmcis/templates/deployment.yaml
@@ -28,6 +28,7 @@ spec:
           args:
             - --tls-cert-file=/tls/tls.crt
             - --tls-private-key-file=/tls/tls.key
+            - --secure-port=6443
 {{- if .Values.logLevel }}
             - --v={{ .Values.logLevel }}
 {{- end }}
@@ -41,7 +42,7 @@ spec:
                   key: api-token
           ports:
             - name: https
-              containerPort: 443
+              containerPort: 6443
               protocol: TCP
           livenessProbe:
             httpGet:

--- a/deploy/cert-manager-webhook-ibmcis/templates/service.yaml
+++ b/deploy/cert-manager-webhook-ibmcis/templates/service.yaml
@@ -12,7 +12,7 @@ spec:
   type: {{ .Values.service.type }}
   ports:
     - port: {{ .Values.service.port }}
-      targetPort: https
+      targetPort: 6443
       protocol: TCP
       name: https
   selector:


### PR DESCRIPTION
Address issue: https://github.com/IBM/cert-manager-webhook-ibmcis/issues/4
Verified with OC version 4.12.7 and cert-manager operator version 1.11.0