### PR TITLE
multi-arch support for webhook

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
-FROM --platform=linux/amd64 golang:1.20.5-alpine AS build_deps
+FROM --platform=$BUILDPLATFORM golang:1.20.5-alpine AS build_deps
 
+ARG TARGETOS TARGETARCH
 RUN apk add --no-cache git
 RUN apk add --no-cache ca-certificates
 
@@ -16,7 +17,7 @@ FROM build_deps AS build
 
 COPY . .
 
-RUN CGO_ENABLED=0 go build -o webhook -ldflags '-w -extldflags "-static"' .
+RUN CGO_ENABLED=0 GOOS=$TARGETOS GOARCH=$TARGETARCH go build -o webhook -ldflags '-w -extldflags "-static"' .
 
 FROM scratch
 

--- a/README.md
+++ b/README.md
@@ -8,11 +8,11 @@ This is a webhook solver for [IBM Cloud Internet Service](https://cloud.ibm.com/
 
 ## Prerequisites
 
-* [cert-manager](https://github.com/jetstack/cert-manager): *tested with 1.32.2* *Kubernetes api 1.28.2*
+* [cert-manager](https://github.com/jetstack/cert-manager): *tested with 1.13.2* *Kubernetes api 1.28.2*
     - [Installing on Kubernetes](https://cert-manager.io/next-docs/installation/kubernetes/)
 
 ```bash
-kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.32.2/cert-manager.yaml
+kubectl apply -f https://github.com/cert-manager/cert-manager/releases/download/v1.13.2/cert-manager.yaml
  # kubectl get pods -n cert-manager
 
 ```
@@ -23,7 +23,9 @@ _Notice: The pod will not startup until the steps under [configuration](#Issuer)
 Assuming your installation has 1. cert-manager running in name-space `cert-manager` and 2. accept this webhook will be installed into namespace `cert-manager-webhook-ibmcis`, 3. the API groups `acme.borup.work` will be used, then it is recommended to install via this pre-defined file .
 
 ```bash
-kubectl apply -f https://raw.githubusercontent.com/IBM/cert-manager-webhook-ibmcis/master/cert-manager-webhook-ibmcis.yaml
+git clone https://github.com/IBM/cert-manager-webhook-ibmcis.git
+cd cert-manager-webhook-ibmcis
+kubectl apply -f cert-manager-webhook-ibmcis.yaml
 ```
 
 ### How cert-manager-webhook-ibmcis.yaml is created (information)

--- a/cert-manager-webhook-ibmcis.yaml
+++ b/cert-manager-webhook-ibmcis.yaml
@@ -186,7 +186,7 @@ spec:
       serviceAccountName: cert-manager-webhook-ibmcis
       containers:
         - name: cert-manager-webhook-ibmcis
-          image: "quay.io/hzhihui/cert-manager-webhook-ibmcis:0.2.1"
+          image: "quay.io/hzhihui/cert-manager-webhook-ibmcis:0.2.2"
           imagePullPolicy: IfNotPresent
           args:
             - --tls-cert-file=/tls/tls.crt

--- a/deploy/cert-manager-webhook-ibmcis/Chart.yaml
+++ b/deploy/cert-manager-webhook-ibmcis/Chart.yaml
@@ -2,4 +2,4 @@ apiVersion: v1
 appVersion: "1.0"
 description: A Helm chart for Kubernetes
 name: cert-manager-webhook-ibmcis
-version: 0.2.1
+version: 0.2.2

--- a/deploy/cert-manager-webhook-ibmcis/values.yaml
+++ b/deploy/cert-manager-webhook-ibmcis/values.yaml
@@ -18,7 +18,7 @@ certManager:
 
 image:
   repository: quay.io/hzhihui/cert-manager-webhook-ibmcis
-  tag: 0.2.1
+  tag: 0.2.2
   pullPolicy: IfNotPresent
 
 nameOverride: ""


### PR DESCRIPTION
Changes to dockerfile to support multi-arch builds.
Tested and works in Power platforms (ppc64le) 
Requesting admin to build and push the multi-arch image
`docker buildx build --push --platform="linux/amd64,linux/ppc64le,linux/s390x" -t quay.io hzhihui/cert-manager-webhook-ibmcis:0.2.2`

Bumped to version 0.2.2 for the multi-arch image.
Cert-manager latest version is 1.13.2 not 1.32.2